### PR TITLE
FEAT : CLOVA Sentiment, Summary

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,9 @@ dependencies {
 	implementation 'com.amazonaws:aws-java-sdk-s3'
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
+	// JSON
+	implementation 'org.json:json:20231013'
+
 	// TEST IMPLEMENTATION ========================
 	// TEST DATABASE H2
 	testImplementation 'com.h2database:h2'

--- a/src/main/java/com/ssg/starroad/common/service/clova/Sentiment.java
+++ b/src/main/java/com/ssg/starroad/common/service/clova/Sentiment.java
@@ -1,0 +1,89 @@
+package com.ssg.starroad.common.service.clova;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ssg.starroad.review.entity.ReviewSentiment;
+import com.ssg.starroad.review.enums.ConfidenceType;
+import lombok.RequiredArgsConstructor;
+import org.json.JSONObject;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class Sentiment {
+
+    private final RestTemplate restTemplate;
+
+    @Value("${clova.client.key.id}")
+    private String CLOVA_API_KEY_ID;
+    @Value("${clova.client.key.secret}")
+    private String CLOVA_API_KEY;
+
+    private final String clovaUrl = "https://naveropenapi.apigw.ntruss.com/sentiment-analysis/v1/analyze";
+
+    public List<ReviewSentiment> getSentiment(String content) {
+
+        // 요청 설정
+        // 요청 헤더 설정
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("X-NCP-APIGW-API-KEY-ID", CLOVA_API_KEY_ID);
+        headers.set("X-NCP-APIGW-API-KEY", CLOVA_API_KEY);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        // 요청 바디 설정
+        JSONObject body = new JSONObject();
+        body.put("content", content);
+
+        // 요청 객체 생성
+        HttpEntity<String> request = new HttpEntity<>(body.toString(), headers);
+
+        // 요청 보내기
+        String response = restTemplate.postForObject(clovaUrl, request, String.class);
+
+        // 응답 받기 위해 준비
+        List<ReviewSentiment> sentimentList = new ArrayList<>();
+        try {
+            // 응답 파싱하기
+            ObjectMapper objectMapper = new ObjectMapper();
+            JsonNode node = objectMapper.readTree(response);
+
+            // document.sentiment 값 가져오기
+            ConfidenceType confidenceType = ConfidenceType.valueOf(node.get("document").get("sentiment").asText().toUpperCase());
+
+            // sentences 값 가져오기
+            JsonNode sentences = node.get("sentences");
+
+            // ReviewSentiment 객체로 변환
+            for (JsonNode sentence : sentences) {
+                ReviewSentiment reviewSentiment = ReviewSentiment.builder()
+                        .content(sentence.get("content").asText())
+                        .confidence(ConfidenceType.valueOf(sentence.get("sentiment").asText().toUpperCase()))
+                        .offset(sentence.get("offset").asInt())
+                        .length(sentence.get("length").asInt())
+                        .highlightLength(sentence.get("highlights").get(0).get("length").asInt())
+                        .highlightOffset(sentence.get("highlights").get(0).get("offset").asInt())
+                        .build();
+
+                // ReviewSentiment 객체 리스트에 추가
+                sentimentList.add(reviewSentiment);
+            }
+        } catch (JsonMappingException e) {
+            e.printStackTrace();
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+        } finally {
+            return sentimentList;
+        }
+    }
+}
+

--- a/src/main/java/com/ssg/starroad/common/service/clova/Summary.java
+++ b/src/main/java/com/ssg/starroad/common/service/clova/Summary.java
@@ -1,0 +1,70 @@
+package com.ssg.starroad.common.service.clova;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.json.JSONObject;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+@RequiredArgsConstructor
+public class Summary {
+
+    private final RestTemplate restTemplate;
+
+    @Value("${clova.client.key.id}")
+    private String CLOVA_API_KEY_ID;
+    @Value("${clova.client.key.secret}")
+    private String CLOVA_API_KEY;
+
+    // Summary API Option 설정
+    private final String OPTION_LANGUAGE = "ko";
+    private final String OPTION_MODEL = "general";
+    private final Integer OPTION_TONE = 3;
+    private final Integer OPTION_SUMMARY_COUNT = 2;
+
+    private final String clovaUrl = "https://naveropenapi.apigw.ntruss.com/text-summary/v1/summarize";
+
+    public String getSummary(String content) {
+
+        // 요청 설정
+        // 요청 헤더 설정
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("X-NCP-APIGW-API-KEY-ID", CLOVA_API_KEY_ID);
+        headers.set("X-NCP-APIGW-API-KEY", CLOVA_API_KEY);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        // 요청 바디 설정
+        JSONObject body = new JSONObject();
+        body.put("document", new JSONObject().put("content", content));
+        body.put("option", new JSONObject()
+                .put("language", OPTION_LANGUAGE)
+                .put("model", OPTION_MODEL)
+                .put("tone", OPTION_TONE)
+                .put("summaryCount", OPTION_SUMMARY_COUNT));
+
+        // 요청 객체 생성
+        HttpEntity<String> request = new HttpEntity<>(body.toString(), headers);
+
+        // 요청 보내기
+        String response = restTemplate.postForObject(clovaUrl, request, String.class);
+
+        try {
+            // 응답 파싱하기
+            ObjectMapper objectMapper = new ObjectMapper();
+            JsonNode node = objectMapper.readTree(response);
+
+            // summary 값 가져오기
+            return node.get("summary").asText();
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+            return "요약 실패";
+        }
+    }
+}

--- a/src/main/java/com/ssg/starroad/config/RootConfig.java
+++ b/src/main/java/com/ssg/starroad/config/RootConfig.java
@@ -7,6 +7,7 @@ import org.modelmapper.convention.MatchingStrategies;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 
 @Configuration
@@ -32,7 +33,14 @@ public class RootConfig {
 
     @Bean
     public RestTemplate restTemplate() {
-        return new RestTemplate();
+        RestTemplate restTemplate = new RestTemplate();
+        SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory(); // 기본적인 HTTP 연결 설정을 제공하는 클래스
+        requestFactory.setConnectTimeout(5000); // 연결 제한시간 5초
+        requestFactory.setReadTimeout(5000); // 읽기 제한시간 5초
+
+        restTemplate.setRequestFactory(requestFactory); // RestTemplate에 위에서 설정한 requestFactory를 설정
+
+        return restTemplate;
     }
 
 }


### PR DESCRIPTION
## CLOVA Sentiment, Summary

## Kinds ✅
- [x] Feature
- [ ] Hotfix
- [ ] Bug Fix
- [ ] Infra

## Description ✏
RestTemplate으로 헤더에 키를 들고 clova에게 post하여 감정과 요약을 반환하도록 하였음

## Changes 🛠
### AS-IS
정훈이 형님이 등록해주신 RestTemplate에 네이버 클로바 sentiment와 summary api post 보내도록 설정

### TO-BE
두개를 적절하게 썩어서 중첩되는 부분있으면 제거하기

## Check List 📝
### Config
- [x] 요청 및 응당 제한 시간 설정

### Component
- [x] Sentiment 설정
- [x] Summary 설정  

## To Reviewers 🙏

